### PR TITLE
added :z option to prevent SELinux problem

### DIFF
--- a/wine-docker-rpm.sh
+++ b/wine-docker-rpm.sh
@@ -70,7 +70,7 @@ sudo systemctl start docker.service
 docker pull fedora:42
 
 #   Starting docker   #
-docker run -e VERSION="${VERSION}" -it --rm -v "$PWD:/out" -v "$PWD:/host" fedora:42 ./host/$TMP_SCRIPT
+docker run -e VERSION="${VERSION}" -it --rm -v "$PWD:/out:z" -v "$PWD:/host:z" fedora:42 ./host/$TMP_SCRIPT
 
 #   Exiting to host   #
 rm "$TMP_SCRIPT"


### PR DESCRIPTION
Hello, I am suggesting docker :z option when mounting local volumes, to prevent SELinux error in Security enforced environment. Script didn't change much, you may look at this.